### PR TITLE
README: mention the download directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ So far, only the following commands are supported:
  * `status`: show the status of images
  * `download`: download images
 
+The images are downloaded to `~/.cache/cockpit-images/`, which matches the
+cockpit default.
+
 ### Examples
 
 Show the summary status of all images:


### PR DESCRIPTION
The default download directory was recently changed to make it "just
work" with cockpit.  Document this change in the README.

Fixes #3
Closes #5